### PR TITLE
Port to Java 8 (suppress Javadoc lint)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,7 +40,7 @@ proto_builddir := $(top_builddir)/protobuf
 spec_title := Asynchronous HBase Client
 spec_vendor := The Async HBase Authors
 # Semantic Versioning (see http://semver.org/).
-spec_version := 1.7.1
+spec_version := 1.7.2
 jar := $(top_builddir)/asynchbase-$(spec_version)-pepperdata-$(TIMESTAMP).jar
 
 asynchbase_PROTOS := \

--- a/pom.xml.in
+++ b/pom.xml.in
@@ -5,7 +5,7 @@
 
   <groupId>org.hbase</groupId>
   <artifactId>asynchbase</artifactId>
-  <version>@spec_version@-pepperdata-SNAPSHOT</version>
+  <version>@spec_version@-pepperdata</version>
   <name>@spec_title@</name>
   <organization>
     <name>@spec_vendor@</name>
@@ -54,6 +54,18 @@
   <inceptionYear>2010</inceptionYear>
 
   <packaging>jar</packaging>
+
+  <profiles>
+    <profile>
+      <id>java8-doclint-disabled</id>
+      <activation>
+        <jdk>[1.8,)</jdk>
+      </activation>
+      <properties>
+        <javadoc.opts>-Xdoclint:none</javadoc.opts>
+      </properties>
+    </profile>
+  </profiles>
 
   <build>
     <sourceDirectory>.mvn-compat/src/main/java</sourceDirectory>
@@ -121,10 +133,28 @@
         <configuration>
           <quiet>true</quiet>
           <validateLinks>true</validateLinks>
+          <additionalparam>${javadoc.opts}</additionalparam>
           <bottom>
             Copyright &#169; {inceptionYear}-{currentYear},
             ${project.organization.name}
           </bottom>
+        </configuration>
+      </plugin>
+
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-site-plugin</artifactId>
+        <version>3.3</version>
+        <configuration>
+          <reportPlugins>
+            <plugin>
+              <groupId>org.apache.maven.plugins</groupId>
+              <artifactId>maven-javadoc-plugin</artifactId>
+              <configuration>
+                <additionalparam>${javadoc.opts}</additionalparam>
+              </configuration>
+            </plugin>
+          </reportPlugins>
         </configuration>
       </plugin>
 


### PR DESCRIPTION
1. I would like to create an independent PD captive asynchbase library, and have it reside in artifactory (for use by projects other than OpenTSDB).  This CL allows us to use Java 8 to build it (the only problems were Javadoc lint introduced in Java 1.8, which is now disabled).
2. This CL also manually bumps up the version to "1.7.2", since we do not have the equivalent of the **prepare_release** shell script (in the OpenTSDB build) to do this, and right now, it is too much work to create one for this purpose.